### PR TITLE
Changed deprecated order rule

### DIFF
--- a/src/.stylelintrc.json
+++ b/src/.stylelintrc.json
@@ -36,7 +36,7 @@
     "no-missing-end-of-source-newline": true,
     "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
-    "order/declaration-block-properties-alphabetical-order": true,
+    "order/properties-alphabetical-order": true,
     "property-no-unknown": true,
     "property-no-vendor-prefix": true,
     "rule-empty-line-before": [


### PR DESCRIPTION
The following rule `"order/declaration-block-properties-alphabetical-order"` has been deprecated
its replacement is  `order/properties-alphabetical-order`

Not using the new `order` rule result in `stylefmt` not being able to fix the `.scss`

(for reference: https://github.com/morishitter/stylefmt/issues/175#issuecomment-293265477 )

After merge, can you publish a new version please ? :-)