### PR TITLE
Update stylelint version to 7.12.0

### DIFF
--- a/__tests__/id-selector.js
+++ b/__tests__/id-selector.js
@@ -21,7 +21,7 @@ test("ID selector scss", t => {
 
   function checkResult(result) {
     t.equal(result.warnings().length, 1, "flags 1 warning")
-    t.is(result.warnings()[0].text, "Unexpected id selector (selector-no-id)", "correct warning text")
+    t.is(result.warnings()[0].text, "Expected \"#id-selector\" to have no more than 0 id selectors (selector-max-id)", "correct warning text")
   }
 })
 

--- a/__tests__/qualifying-element.js
+++ b/__tests__/qualifying-element.js
@@ -33,7 +33,7 @@ test("Qualifying element scss", t => {
 
   function checkResult(result) {
     t.equal(result.warnings().length, 5, "flags 5 warning")
-    t.is(result.warnings()[0].text, "Unexpected id selector (selector-no-id)", "correct warning text")
+    t.is(result.warnings()[0].text, "Expected \"div#thing\" to have no more than 0 id selectors (selector-max-id)", "correct warning text")
     t.is(result.warnings()[1].text, "Unexpected qualifying type selector (selector-no-qualifying-type)", "correct warning text")
     t.is(result.warnings()[2].text, "Unexpected qualifying type selector (selector-no-qualifying-type)", "correct warning text")
     t.is(result.warnings()[3].text, "Unexpected qualifying type selector (selector-no-qualifying-type)", "correct warning text")

--- a/__tests__/single-line-per-property.js
+++ b/__tests__/single-line-per-property.js
@@ -25,7 +25,7 @@ test("Single line per property scss", t => {
     t.equal(result.warnings().length, 3, "flags 3 warning")
     t.is(result.warnings()[0].text, "Expected newline after \";\" (declaration-block-semicolon-newline-after)", "correct warning text")
     t.is(result.warnings()[1].text, "Expected newline after \";\" (declaration-block-semicolon-newline-after)", "correct warning text")
-    t.is(result.warnings()[2].text, "Expected no more than 1 declaration(s) (declaration-block-single-line-max-declarations)", "correct warning text")
+    t.is(result.warnings()[2].text, "Expected no more than 1 declaration (declaration-block-single-line-max-declarations)", "correct warning text")
   }
 })
 

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = {
     ],
     "selector-list-comma-newline-after": "always",
     "selector-max-compound-selectors": 3,
-    "selector-no-id": true,
+    "selector-max-id": 0,
     "selector-no-qualifying-type": true,
     "selector-no-vendor-prefix": true,
     "selector-pseudo-element-colon-notation": "double",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "nyc": "^7.0.0",
     "rename-files": "0.0.2",
     "replace": "^0.3.0",
-    "stylelint": "^7.8.0",
+    "stylelint": "^7.12.0",
     "tape": "^4.2.0"
   },
   "scripts": {

--- a/src/.stylelintrc.json
+++ b/src/.stylelintrc.json
@@ -68,7 +68,7 @@
     ],
     "selector-list-comma-newline-after": "always",
     "selector-max-compound-selectors": 3,
-    "selector-no-id": true,
+    "selector-max-id": 0,
     "selector-no-qualifying-type": true,
     "selector-no-vendor-prefix": true,
     "selector-pseudo-element-colon-notation": "double",


### PR DESCRIPTION
As mentionned in #8 the rule `selector-no-id` has been deprecated.
Its replacement is `selector-max-id`with 0 as its primary option.

So i updated stylelint version and i upgraded tests accordingly.