### PR TITLE
Add rules & tests for declaration-order

### DIFF
--- a/__tests__/declaration-order.js
+++ b/__tests__/declaration-order.js
@@ -1,11 +1,10 @@
-import config from "../"
-import stylelint from "stylelint"
-import postcss from "postcss"
-import scssSyntax from "postcss-scss"
-import test from "tape"
+import config from '../'
+import stylelint from 'stylelint'
+import postcss from 'postcss'
+import scssSyntax from 'postcss-scss'
+import test from 'tape'
 
-const invalidScss = (
-`// scss features not lintable for declaration order in stylelint
+const invalidScss = `// scss features not lintable for declaration order in stylelint
 .declarationorder {
   p {
     color: #f00;
@@ -17,20 +16,40 @@ const invalidScss = (
   @extend %error;
 }
 
-`)
+`
 
-test("Declaration order scss", t => {
-  t.plan(2)
+test('Declaration order scss', t => {
+  t.plan(5)
 
   postcss()
-    .use(stylelint({ code: invalidScss, config: config,}))
+    .use(stylelint({ code: invalidScss, config: config }))
     .process(invalidScss, { syntax: scssSyntax })
     .then(checkResult)
     .catch(logError)
 
   function checkResult(result) {
-    t.equal(result.warnings().length, 1, "flags 1 warning")
-    t.is(result.warnings()[0].text, "Expected background-color to come before color (order/properties-alphabetical-order)", "correct warning text")
+    console.log(result)
+    t.equal(result.warnings().length, 4, 'flags 4 warnings')
+    t.is(
+      result.warnings()[0].text,
+      'Expected declaration to come before rule (order/order)',
+      'correct warning text',
+    )
+    t.is(
+      result.warnings()[1].text,
+      'Expected blockless @include to come before declaration (order/order)',
+      'correct warning text',
+    )
+    t.is(
+      result.warnings()[2].text,
+      'Expected @extend to come before blockless @include (order/order)',
+      'correct warning text',
+    )
+    t.is(
+      result.warnings()[3].text,
+      'Expected background-color to come before color (order/properties-alphabetical-order)',
+      'correct warning text',
+    )
   }
 })
 

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
 module.exports = {
- "plugins": [
-    "stylelint-order",
-    "stylelint-scss"
-  ],
+ "plugins": ["stylelint-order", "stylelint-scss"],
   "rules": {
     "at-rule-blacklist": ["debug"],
     "at-rule-no-vendor-prefix": true,
@@ -21,9 +18,7 @@ module.exports = {
     "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",
     "declaration-property-value-blacklist": {
-      "/^border/": [
-        "none"
-      ]
+      "/^border/": ["none"]
     },
     "function-comma-space-after": "always-single-line",
     "function-parentheses-space-inside": "never",
@@ -36,18 +31,48 @@ module.exports = {
     "no-missing-end-of-source-newline": true,
     "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
+    "order/order": [
+      [
+        "custom-properties",
+        "dollar-variables",
+        {
+          "type": "at-rule",
+          "name": "extend"
+        },
+        {
+          "type": "at-rule",
+          "name": "include",
+          "hasBlock": false
+        },
+        "declarations",
+        {
+          "type": "at-rule",
+          "hasBlock": true
+        },
+        {
+          "type": "at-rule",
+          "name": "include",
+          "hasBlock": true
+        },
+        {
+          "type": "rule",
+          "selector": "/^&:\\w/"
+        },
+        {
+          "type": "rule",
+          "selector": "/^&::\\w/"
+        },
+        "rules"
+      ]
+    ],
     "order/properties-alphabetical-order": true,
     "property-no-unknown": true,
     "property-no-vendor-prefix": true,
     "rule-empty-line-before": [
       "always-multi-line",
       {
-        "except": [
-          "first-nested"
-        ],
-        "ignore": [
-          "after-comment"
-        ]
+        "except": ["first-nested"],
+        "ignore": ["after-comment"]
       }
     ],
     "scss/at-extend-no-missing-placeholder": true,
@@ -63,7 +88,8 @@ module.exports = {
     "selector-class-pattern": [
       "^[a-z0-9\\-]+$",
       {
-        "message": "Selector should be written in lowercase with hyphens (selector-class-pattern)"
+        "message":
+          "Selector should be written in lowercase with hyphens (selector-class-pattern)"
       }
     ],
     "selector-list-comma-newline-after": "always",

--- a/src/.stylelintrc.json
+++ b/src/.stylelintrc.json
@@ -1,8 +1,5 @@
 {
-  "plugins": [
-    "stylelint-order",
-    "stylelint-scss"
-  ],
+  "plugins": ["stylelint-order", "stylelint-scss"],
   "rules": {
     "at-rule-blacklist": ["debug"],
     "at-rule-no-vendor-prefix": true,
@@ -21,9 +18,7 @@
     "declaration-colon-space-after": "always-single-line",
     "declaration-colon-space-before": "never",
     "declaration-property-value-blacklist": {
-      "/^border/": [
-        "none"
-      ]
+      "/^border/": ["none"]
     },
     "function-comma-space-after": "always-single-line",
     "function-parentheses-space-inside": "never",
@@ -36,18 +31,48 @@
     "no-missing-end-of-source-newline": true,
     "number-leading-zero": "always",
     "number-no-trailing-zeros": true,
+    "order/order": [
+      [
+        "custom-properties",
+        "dollar-variables",
+        {
+          "type": "at-rule",
+          "name": "extend"
+        },
+        {
+          "type": "at-rule",
+          "name": "include",
+          "hasBlock": false
+        },
+        "declarations",
+        {
+          "type": "at-rule",
+          "hasBlock": true
+        },
+        {
+          "type": "at-rule",
+          "name": "include",
+          "hasBlock": true
+        },
+        {
+          "type": "rule",
+          "selector": "/^&:\\w/"
+        },
+        {
+          "type": "rule",
+          "selector": "/^&::\\w/"
+        },
+        "rules"
+      ]
+    ],
     "order/properties-alphabetical-order": true,
     "property-no-unknown": true,
     "property-no-vendor-prefix": true,
     "rule-empty-line-before": [
       "always-multi-line",
       {
-        "except": [
-          "first-nested"
-        ],
-        "ignore": [
-          "after-comment"
-        ]
+        "except": ["first-nested"],
+        "ignore": ["after-comment"]
       }
     ],
     "scss/at-extend-no-missing-placeholder": true,
@@ -63,7 +88,8 @@
     "selector-class-pattern": [
       "^[a-z0-9\\-]+$",
       {
-        "message": "Selector should be written in lowercase with hyphens (selector-class-pattern)"
+        "message":
+          "Selector should be written in lowercase with hyphens (selector-class-pattern)"
       }
     ],
     "selector-list-comma-newline-after": "always",


### PR DESCRIPTION
Should allow `stylelint` to enforce ordering, _a la_ `scss-lint` (see: https://github.com/bjankord/stylelint-config-sass-guidelines/wiki/Lint-Report-Comparison#declaration-order-details).

Let me know if you'd like me to expand the tests or update anything!