### PR TITLE
chore: make running test compatible with Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "scss-lint-passing-case": "cd src; bundle exec scss-lint passing-test-cases.scss -c .scss-lint.yml; exit 0",
     "stylelint-failing-case": "cd src; stylelint failing-test-cases.scss; exit 0",
     "stylelint-passing-case": "cd src; stylelint passing-test-cases.scss; exit 0",
-    "tape": "babel-tape-runner '__tests__/**/*.js'",
+    "tape": "babel-tape-runner \"__tests__/**/*.js\"",
     "test": "npm run build && nyc npm run tape"
   },
   "babel": {


### PR DESCRIPTION
For Linux systems '' and "" both work as delimiters, on Windows only ""
works.