### PR TITLE
Update dependency ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [5.3.0]
+### Changed
+- Updated `stylelint-order` dependency range to pull in 1.x or 2.x versions. Both major versions are compatible.
+- Updated up `stylelint-scss` dependency to pull minimum of 3.4.0 [PR]
+
 ## [5.2.0]
 ### Changed
 - Bumped up `stylelint-order` dependency to ^1.0.0 [PR](https://github.com/bjankord/stylelint-config-sass-guidelines/pull/32)

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "node": ">=6"
   },
   "dependencies": {
-    "stylelint-order": "^1.0.0",
-    "stylelint-scss": "^3.0.0"
+    "stylelint-order": ">=1.0.0",
+    "stylelint-scss": "^3.4.0"
   },
   "peerDependencies": {
     "stylelint": "^9.0.0"


### PR DESCRIPTION
- Updated `stylelint-order` dependency range to pull in 1.x or 2.x versions. Both major versions are compatible.
- Updated up `stylelint-scss` dependency to pull minimum version of 3.4.0