### PR TITLE
Update stylelint and stylelint-order versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ cache:
     - node_modules
 
 node_js:
-  - '6'
+  - '8'
 
 before_install:
   # remove outdated deps, assists with cache maintenance

--- a/package.json
+++ b/package.json
@@ -25,14 +25,14 @@
     "index.js"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8.7.0"
   },
   "dependencies": {
-    "stylelint-order": ">=1.0.0",
+    "stylelint-order": "^3.0.0",
     "stylelint-scss": "^3.4.0"
   },
   "peerDependencies": {
-    "stylelint": "^9.0.0"
+    "stylelint": "^10.0.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.2.0",
@@ -41,7 +41,7 @@
     "babel-tape-runner": "^3.0.0",
     "prepend-file": "^1.3.1",
     "shelljs": "^0.8.1",
-    "stylelint": "^9.0.0",
+    "stylelint": "^10.0.1",
     "tape": "^4.2.0"
   },
   "scripts": {


### PR DESCRIPTION
* Update stylelint and stylelint-order versions to new major releases
* Drop support for node 6, update node engine to 8.7.0 similar to stylelint - https://github.com/stylelint/stylelint/pull/4032