### PR TITLE
fix link to german translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A stylelint config based on [sass-guidelin.es](https://sass-guidelin.es/)
 
 # Translations
 
-* [Deutsch](page/de)
+* [Deutsch](page/de.md)
 
 ## Installation
 

--- a/page/de.md
+++ b/page/de.md
@@ -13,7 +13,7 @@
 
 Diese Konfiguration basiert auf [sass-guidelin.es](https://sass-guidelin.es/)
 
-Zurück zur [englischen Version](../README)
+Zurück zur [englischen Version](../README.md)
 
 # Installation
 


### PR DESCRIPTION
I fixed the link to the german translation. And the link back to the english version if you're on the german version of the README.md file.