### PR TITLE
Add missing 'ruleName' property

### DIFF
--- a/src/.stylelintrc.json
+++ b/src/.stylelintrc.json
@@ -1,4 +1,5 @@
 {
+  "ruleName": "plugin/stylelint-config-sass-guidelines",
   "plugins": ["stylelint-order", "stylelint-scss"],
   "rules": {
     "at-rule-disallowed-list": ["debug"],


### PR DESCRIPTION
Adds the missing `ruleName` property to the plugin config.

Relates to issue #122 