### PR TITLE
Add extension of stylelint-config-recommended

### DIFF
--- a/src/.stylelintrc.json
+++ b/src/.stylelintrc.json
@@ -1,5 +1,5 @@
 {
-  "extends": "stylelint-config-recommended",
+  "extends": "stylelint-config-recommended-scss",
   "plugins": ["stylelint-order", "stylelint-scss"],
   "rules": {
     "at-rule-disallowed-list": ["debug"],

--- a/src/.stylelintrc.json
+++ b/src/.stylelintrc.json
@@ -1,4 +1,5 @@
 {
+  "extends": "stylelint-config-recommended",
   "plugins": ["stylelint-order", "stylelint-scss"],
   "rules": {
     "at-rule-disallowed-list": ["debug"],


### PR DESCRIPTION
### Add [`stylelint-config-recommended`](https://github.com/stylelint/stylelint-config-recommended) since it turns on all the possible _error_ rules within stylelint.

A few examples of why this is useful: 
- while the stylelint here has no opinions on duplicate properties, `stylelint-config-recommended` lints for several types of duplicates, eg `declaration-block-no-duplicate-custom-properties` and etc. 
- `no-extra-semicolons`
- `function-calc-no-invalid`
- `named-grid-areas-no-invalid`
- `no-invalid-double-slash-comments`
- etc

See [here](https://github.com/stylelint/stylelint-config-recommended/blob/master/index.js) for all the errors that it lints for