### PR TITLE
Remove scss/at-mixin-pattern rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - "number-no-trailing-zeros": true
   - "selector-list-comma-newline-after": "always"
   - "string-quotes": "single"
+- Removed scss/at-mixin-pattern rule. Resolves [#181](https://github.com/bjankord/stylelint-config-sass-guidelines/issues/181) and [#191](https://github.com/bjankord/stylelint-config-sass-guidelines/issues/191)
 
 ## [9.0.1]
 ### Changed

--- a/__tests__/unit/name-format.spec.js
+++ b/__tests__/unit/name-format.spec.js
@@ -21,7 +21,7 @@ $myVar: 10px;
 `)
 
 test("Name format scss", t => {
-  t.plan(5)
+  t.plan(4)
 
   postcss()
     .use(stylelint({ code: invalidScss, config: config,}))
@@ -30,15 +30,10 @@ test("Name format scss", t => {
     .catch(logError)
 
   function checkResult(result) {
-    t.equal(result.warnings().length, 4, "flags 4 warning")
+    t.equal(result.warnings().length, 3, "flags 3 warning")
     var warningsArray = Object.values(result.warnings()).map(x => x.text);
     t.is(
       warningsArray.includes('Expected @function name to match specified pattern (scss/at-function-pattern)'),
-      true,
-      'correct warning text',
-    )
-    t.is(
-      warningsArray.includes('Expected @mixin name to match specified pattern (scss/at-mixin-pattern)'),
       true,
       'correct warning text',
     )

--- a/index.js
+++ b/index.js
@@ -44,7 +44,6 @@ module.exports = {
     "scss/at-function-pattern": "^[a-z]+([a-z0-9-]+[a-z0-9]+)?$",
     "scss/at-import-no-partial-leading-underscore": true,
     "scss/at-import-partial-extension-blacklist": ["scss"],
-    "scss/at-mixin-pattern": "^[a-z]+([a-z0-9-]+[a-z0-9]+)?$",
     "scss/at-rule-no-unknown": true,
     "scss/dollar-variable-colon-space-after": "always",
     "scss/dollar-variable-colon-space-before": "never",


### PR DESCRIPTION
Resolves #181 
Resolves #191 

Update to allow people to write mixins however they need.
If you find that you need this functionality, you can add the rule back to your config with the following:

```js
{
  "extends": "stylelint-config-sass-guidelines",
  "rules": {
    "scss/at-mixin-pattern": "^[a-z]+([a-z0-9-]+[a-z0-9]+)?$",
  }
}
```